### PR TITLE
Move the stack to an usable location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,4 +51,4 @@ ninjastorms_LDFLAGS = -T kernel/link-arm-eabi.ld -Ttext $(LOADADDR)
 
 # workaround for generating plain binaries for arm targets
 all-local: $(noinst_PROGRAMS)
-	if file $< | grep executable >/dev/null; then $(STRIP) -O binary $<; fi
+	if file $< | grep executable >/dev/null; then $(STRIP) -O binary -o bin $<; fi

--- a/kernel/boot/start.S
+++ b/kernel/boot/start.S
@@ -57,8 +57,6 @@ init_array_loop:
   add   r0, r0, #4
   b     init_array_loop
 init_array_loop_end:
-  ldr   r2, [r0]
-  blx   r2
 
   // restore r0-r2
   pop   {r0-r2}

--- a/kernel/boot/start.S
+++ b/kernel/boot/start.S
@@ -22,8 +22,9 @@
 
 .globl Start
 Start:
+
   // setup the stack
-  mov   sp, #0x8000
+  ldr   sp, =__bss_end
 
   // save registers r0-r2 for kernel main
   push  {r0-r2}
@@ -45,6 +46,7 @@ bss_clear_loop_end:
   ldr   r0, =__init_array_start
   ldr   r1, =__init_array_end
 
+// call init functions
 init_array_loop:
   cmp   r0, r1
   beq   init_array_loop_end
@@ -55,6 +57,8 @@ init_array_loop:
   add   r0, r0, #4
   b     init_array_loop
 init_array_loop_end:
+  ldr   r2, [r0]
+  blx   r2
 
   // restore r0-r2
   pop   {r0-r2}

--- a/kernel/link-arm-eabi.ld
+++ b/kernel/link-arm-eabi.ld
@@ -46,6 +46,7 @@ SECTIONS
   {
     *(.bss .bss.*)
     . = ALIGN(. != 0 ? 32 / 8 : 1);
+    . += 8K;
   }
   __bss_end = .;
 


### PR DESCRIPTION
I did some debugging and found that it was dying inside the init functions as soon as you touch anything.
It turns out `0x8000` is not a good place to put the stack. So I added a bit of memory to `.bss` and put it there.

It currently boots and prints it's ready, but pressing the button does not seem to start the demo's or they are broken.

At least it boots...