### PR TITLE
Add u-boot make targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,9 +49,9 @@ ninjastorms_SOURCES = \
 ninjastorms_LDADD = libc/libc.la -lgcc
 ninjastorms_LDFLAGS = -T kernel/link-arm-eabi.ld -Ttext $(LOADADDR)
 
-# workaround for generating plain binaries for arm targets
-all-local: $(noinst_PROGRAMS).bin
+all-local: uImage
 
+# workaround for generating plain binaries for arm targets
 $(noinst_PROGRAMS).bin: $(noinst_PROGRAMS)
 	if file $< | grep executable >/dev/null; then $(STRIP) -O binary -o $<.bin $<; fi
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,5 +50,17 @@ ninjastorms_LDADD = libc/libc.la -lgcc
 ninjastorms_LDFLAGS = -T kernel/link-arm-eabi.ld -Ttext $(LOADADDR)
 
 # workaround for generating plain binaries for arm targets
-all-local: $(noinst_PROGRAMS)
-	if file $< | grep executable >/dev/null; then $(STRIP) -O binary -o bin $<; fi
+all-local: $(noinst_PROGRAMS).bin
+
+$(noinst_PROGRAMS).bin: $(noinst_PROGRAMS)
+	if file $< | grep executable >/dev/null; then $(STRIP) -O binary -o $<.bin $<; fi
+
+# generate a boot.scr for booting via ymodem download
+boot.scr: boot.cmd
+	@echo "  MKIMAGE  boot.scr"
+	$(Q)mkimage -C none -A arm -T script -d boot.cmd boot.scr
+
+# generate uImage for downloading or booting directly from SD
+uImage: $(noinst_PROGRAMS).bin
+	@echo "  MKIMAGE  ninjastorms"
+	$(Q)mkimage -C none -A arm -T kernel -O linux -a $(LOADADDR) -e $(LOADADDR)  -d $< uImage

--- a/boot.cmd
+++ b/boot.cmd
@@ -1,0 +1,3 @@
+loady ${loadaddr}
+run mmcargs;
+run mmcboot;


### PR DESCRIPTION
As discussed in #10, I added make targets that generate u-boot files.
By default a uImage is created that can directly boot form an SD FAT partition.
`make boot.scr` will get you a script that mimics the default boot procedure, but loads the uImage over ymodem.

Note that the bare binary now has a different name, as in-place stripping made debugging harder. Now you can simply do `arm-none-eabi-objdump -d ninjastorms` to see what was generated.